### PR TITLE
Fixing https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command

### DIFF
--- a/requirements27.txt
+++ b/requirements27.txt
@@ -21,7 +21,6 @@ nose-parameterized==0.6.0
 numpy==1.12.1
 packaging==16.8
 pandas==0.20.1
-pkg-resources==0.0.0
 plac==0.9.6
 pyparsing==2.2.0
 python-dateutil==2.6.0

--- a/requirements35.txt
+++ b/requirements35.txt
@@ -17,7 +17,6 @@ numpy==1.12.1
 packaging==16.8
 pandas==0.20.1
 parameterized==0.6.1
-pkg-resources==0.0.0
 plac==0.9.6
 pyparsing==2.2.0
 python-dateutil==2.6.0


### PR DESCRIPTION
Probably from a `pip freeze` output `requirements35.tx`t include `pkg-resources==0.0.0` in line 20, causing a problem in the `venv` creation. 

```bash
Collecting parameterized==0.6.1 (from -r requirements35.txt (line 19))
  Using cached parameterized-0.6.1-py2.py3-none-any.whl
Collecting pkg-resources==0.0.0 (from -r requirements35.txt (line 20))
  Could not find a version that satisfies the requirement pkg-resources==0.0.0 (from -r requirements35.txt (line 20)) (from versions: )
No matching distribution found for pkg-resources==0.0.0 (from -r requirements35.txt (line 20))

```

Check this StackOverflow [question](https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command), for example.