### PR TITLE
Fix instructions for venv setup in Python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install system packages
 Install remaining packages in virtualenv
 
     virtualenv -p `which python3` venv35
-    venv27/bin/pip3 install -r requirements27.txt
+    venv35/bin/pip3 install -r requirements35.txt
 
 ## MS Windows, using Python 2.7, anaconda
 


### PR DESCRIPTION
Hi! I've corrected a mistake in the instructions to setup the VirtualEnv in Linux for Python 3.5 (as it was trying to use the pip binaries and requirements file for 2.7)